### PR TITLE
Adding tensorboardX requirement (for QA models)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ fastBPE
 sklearn
 ujson
 spacy
+tensorboardX


### PR DESCRIPTION
QA model training with `pytorch_transformers/examples/run_squad.py` requires `tensorboardX` dependency to plot training stats.